### PR TITLE
fix example for latest budo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ Stateless virtual dom &lt;-&gt; Redux
 
 ### Running the examples
 
-    $ cd examples/basic && budo --live -t babelify index.js
+    $ cd examples/basic && budo --live index.js -- -t babelify
 
 ## Setup
 


### PR DESCRIPTION
looks like later versions of budo now pass options directly into browserify after the dashes.
